### PR TITLE
Improve log entries saving and fix kill log entry

### DIFF
--- a/paper/src/main/java/com/untamedears/jukealert/JukeAlert.java
+++ b/paper/src/main/java/com/untamedears/jukealert/JukeAlert.java
@@ -70,7 +70,7 @@ public class JukeAlert extends ACivMod {
 
 	@Override
 	public void onDisable() {
-		snitchManager.shutDown();
+		snitchManager.shutdown();
 		if (this.taskChainFactory != null) {
 			this.taskChainFactory.shutdown(10, TimeUnit.SECONDS);
 			this.taskChainFactory = null;
@@ -102,7 +102,10 @@ public class JukeAlert extends ACivMod {
 			Bukkit.shutdown();
 			return;
 		}
+
 		snitchManager = new SnitchManager(api);
+		snitchManager.enable();
+
 		settingsManager = new JASettingsManager();
 		commandManager = new JACommandManager(this);
 		registerJukeAlertEvents();

--- a/paper/src/main/java/com/untamedears/jukealert/SnitchManager.java
+++ b/paper/src/main/java/com/untamedears/jukealert/SnitchManager.java
@@ -1,14 +1,23 @@
 package com.untamedears.jukealert;
 
+import com.untamedears.jukealert.database.JukeAlertDAO;
 import com.untamedears.jukealert.model.Snitch;
 import com.untamedears.jukealert.model.SnitchQTEntry;
+
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
+
+import com.untamedears.jukealert.model.actions.ActionCacheState;
+import com.untamedears.jukealert.model.actions.abstr.LoggablePlayerAction;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import vg.civcraft.mc.civmodcore.world.locations.SparseQuadTree;
@@ -17,16 +26,44 @@ import vg.civcraft.mc.civmodcore.world.locations.chunkmeta.api.SingleBlockAPIVie
 import vg.civcraft.mc.namelayer.group.Group;
 
 public class SnitchManager {
+	private static final long SAVE_LOGS_INTERVAL_MS = 60L * 1000L; // 1 min
 
-	private SingleBlockAPIView<Snitch> api;
-	private Map<UUID, SparseQuadTree<SnitchQTEntry>> quadTreesByWorld;
+	private record LogItem(int internalActionId, Snitch snitch, LoggablePlayerAction action){}
+
+	private final SingleBlockAPIView<Snitch> api;
+	private final Map<UUID, SparseQuadTree<SnitchQTEntry>> quadTreesByWorld;
+	private final ScheduledExecutorService scheduler;
+	private final ConcurrentLinkedQueue<LogItem> logs;
 
 	public SnitchManager(SingleBlockAPIView<Snitch> api) {
 		this.api = api;
 		this.quadTreesByWorld = new TreeMap<>();
+		this.scheduler = Executors.newScheduledThreadPool(1);
+		this.logs = new ConcurrentLinkedQueue<>();
 	}
 
-	public void shutDown() {
+	public void enable() {
+		scheduler.scheduleWithFixedDelay(() -> {
+			saveLogsToDB();
+		}, SAVE_LOGS_INTERVAL_MS, SAVE_LOGS_INTERVAL_MS, TimeUnit.MILLISECONDS);
+	}
+
+	public void shutdown() {
+		scheduler.shutdown();
+
+		try {
+			if (!scheduler.awaitTermination(60, TimeUnit.SECONDS))
+				scheduler.shutdownNow();
+		} catch (InterruptedException ex) {
+			ex.printStackTrace();
+		}
+
+		JukeAlert.getInstance().getLogger().info("SnitchManager scheduler and its tasks are shutdown.");
+
+		saveLogsToDB();
+
+		JukeAlert.getInstance().getLogger().info("Snitch logs are saved.");
+
 		api.disable();
 	}
 
@@ -105,4 +142,18 @@ public class SnitchManager {
  		return result;
 	}
 
+	public void saveLog(int internalActionId, Snitch snitch, LoggablePlayerAction action) {
+		logs.add(new LogItem(internalActionId, snitch, action));
+	}
+
+	private void saveLogsToDB() {
+		JukeAlertDAO dao = JukeAlert.getInstance().getDAO();
+
+		LogItem logItem;
+		while ((logItem = logs.poll()) != null) {
+			final int actionID = dao.insertLog(logItem.internalActionId, logItem.snitch, logItem.action.getPersistence());
+			logItem.action.setID(actionID);
+			logItem.action.setCacheState(ActionCacheState.NORMAL);
+		}
+	}
 }

--- a/paper/src/main/java/com/untamedears/jukealert/database/JukeAlertDAO.java
+++ b/paper/src/main/java/com/untamedears/jukealert/database/JukeAlertDAO.java
@@ -573,23 +573,6 @@ public class JukeAlertDAO extends GlobalTrackableDAO<Snitch> {
 	}
 
 	/**
-	 * Inserts a new snitch log to the database asynchronously.
-	 *
-	 * @param actionTypeID The internal ID of the action type.
-	 * @param snitch The snitch to save the log to.
-	 * @param action The action to store in the database.
-	 */
-	public void insertLogAsync(final int actionTypeID,
-							   @Nonnull final Snitch snitch,
-							   @Nonnull final LoggablePlayerAction action) {
-		Bukkit.getScheduler().runTaskAsynchronously(JukeAlert.getInstance(), () -> {
-			final int actionID = insertLog(actionTypeID, snitch, action.getPersistence());
-			action.setID(actionID);
-			action.setCacheState(ActionCacheState.NORMAL);
-		});
-	}
-
-	/**
 	 * Deletes a particular log from the database.
 	 *
 	 * @param log The log to delete.

--- a/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/KillPlayerAction.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/KillPlayerAction.java
@@ -37,7 +37,7 @@ public class KillPlayerAction extends LoggablePlayerVictimAction {
 	
 	@Override
 	protected String getChatRepresentationIdentifier() {
-		return "Killed " + getVictim();
+		return "Killed " + getVictimName();
 	}
 
 	@Override

--- a/paper/src/main/java/com/untamedears/jukealert/model/appender/SnitchLogAppender.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/appender/SnitchLogAppender.java
@@ -90,7 +90,8 @@ public class SnitchLogAppender extends ConfigurableSnitchAppender<LimitedActionT
 			this.pendingActions.put(log, internalActionID);
 			return;
 		}
-		JukeAlert.getInstance().getDAO().insertLogAsync(internalActionID, getSnitch(), log);
+
+		JukeAlert.getInstance().getSnitchManager().saveLog(internalActionID, getSnitch(), log);
 	}
 
 	/** {@inheritDoc} */


### PR DESCRIPTION
1. Use one scheduled async task instead of multiple async tasks for saving log entries
2. Show player name instead of id in snitch logs