### PR TITLE
Issue #23: [Regression] /jainfo arguments don't work

### DIFF
--- a/paper/src/main/java/com/untamedears/jukealert/commands/InfoCommand.java
+++ b/paper/src/main/java/com/untamedears/jukealert/commands/InfoCommand.java
@@ -20,79 +20,193 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.ChatColor;
-import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import vg.civcraft.mc.namelayer.NameAPI;
 
 public class InfoCommand extends BaseCommand {
+	private class FilterOptions {
+		public Integer snitchId;
+		public Integer pageNumber;
+		public String actionType;
+		public String playerName;
+		public boolean censor;
+	}
 
-	private static final String[] autocompleteCommands = { "next", "censor", "action=", "player=" };
+	private static final Map<UUID, FilterOptions> _history = new ConcurrentHashMap<>();
 
 	@CommandAlias("jainfo")
 	@Description("Display information from a snitch")
-	@Syntax("[page number_or_'next'] [censor] [action=action_type] [player=player_name]")
-	public void execute(Player player, @Optional String pageNumber) {
+	@Syntax("[next | ([page_number] [censor] [action=action_type] [player=player_name])]")
+	public void execute(Player player) {
+		executeCommand(player, new FilterOptions());
+	}
+
+	@CommandAlias("jainfo")
+	@Description("Display information from a snitch")
+	@Syntax("[next | ([page_number] [censor] [action=action_type] [player=player_name])]")
+	public void execute(Player player,
+			String option1,
+			@Optional String option2,
+			@Optional String option3,
+			@Optional String option4)
+	{
+		if ((option2 == null || option2.length() == 0) && option1.equalsIgnoreCase("next")) {
+			executeNextCommand(player);
+			return;
+		}
+
+		var options = new FilterOptions();
+
+		if (parseOption(player, option1, options, true)
+				&& parseOption(player, option2, options, false)
+				&& parseOption(player, option3, options, false)
+				&& parseOption(player, option4, options, false))
+		{
+			executeCommand(player, options);
+		}
+	}
+
+	private static boolean parseOption(
+			Player player,
+			String optionText,
+			FilterOptions options,
+			boolean allowPageNumber)
+	{
+		if (optionText == null || optionText.length() == 0) {
+			return true;
+		}
+
+		if (allowPageNumber && parsePageNumber(optionText, options)) {
+			return true;
+		}
+
+		String loweredOptionText = optionText.toLowerCase();
+
+		if (loweredOptionText.equals("censor")) {
+			if (options.censor) {
+				player.sendMessage(Component.text("The option 'censor' is declared more than once", NamedTextColor.RED));
+				return false;
+			}
+			options.censor = true;
+		} else if (loweredOptionText.startsWith("action=")) {
+			if (options.actionType != null) {
+				player.sendMessage(Component.text("The option 'action' is declared more than once", NamedTextColor.RED));
+				return false;
+			}
+			options.actionType = optionText.substring("action=".length());
+		} else if (loweredOptionText.startsWith("player=")) {
+			if (options.playerName != null) {
+				player.sendMessage(Component.text("The option 'player' is declared more than once", NamedTextColor.RED));
+				return false;
+			}
+			options.playerName = optionText.substring("player=".length());
+		} else if (loweredOptionText.equals("next")) {
+			player.sendMessage(Component.text("The keyword 'next' cannot be used in this context", NamedTextColor.RED));
+			return false;
+		} else {
+			player.sendMessage(Component.text("The unknown option: " + optionText, NamedTextColor.RED));
+			return false;
+		}
+
+		return true;
+	}
+
+	private static boolean parsePageNumber(String optionText, FilterOptions options) {
+		try {
+			int pageNumber = Integer.parseInt(optionText);
+			options.pageNumber = pageNumber;
+		} catch (NumberFormatException e) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private void executeNextCommand(Player player) {
+		FilterOptions options = _history.get(player.getUniqueId());
+
+		if (options != null) {
+			options.pageNumber++;
+		} else {
+			options = new FilterOptions();
+		}
+
+		executeCommand(player, options);
+	}
+
+	private void executeCommand(Player player, FilterOptions options)
+	{
 		Snitch snitch = findLookingAtOrClosestSnitch(player, JukeAlertPermissionHandler.getReadLogs());
 		if (snitch == null) {
-			player.sendMessage(
-					ChatColor.RED + " You do not own any snitches nearby or lack permission to view their logs!");
+			player.sendMessage(Component.text("You do not own any snitches nearby or lack permission to view their logs!",
+					NamedTextColor.RED));
 			return;
 		}
 		if (!snitch.hasAppender(SnitchLogAppender.class)) {
-			player.sendMessage(ChatColor.RED + "This " + snitch.getType().getName() + " named " + snitch.getName()
-					+ " can not save logs");
+			player.sendMessage(Component.text("This " + snitch.getType().getName() + " named " + snitch.getName()
+							+ " can not save logs",
+					NamedTextColor.RED));
 			return;
 		}
-		int offset = 0;
-		String filterAction = null;
-		String filterPlayer = null;
-		if (pageNumber != null) {
-			try {
-				offset = Integer.parseInt(pageNumber);
-			} catch (NumberFormatException e) {
-				player.sendMessage(ChatColor.RED + pageNumber + " is not a number");
-				return;
-			}
+
+		if (options.snitchId != null && options.snitchId != snitch.getId()) {
+			options = new FilterOptions();
 		}
-		if (offset < 0) {
+
+		options.snitchId = snitch.getId();
+
+		if (options.pageNumber == null) {
+			options.pageNumber = 0;
+		}
+		else if (options.pageNumber < 0) {
 			player.sendMessage(Component.text("You cannot input a negative number here").color(NamedTextColor.RED));
 			return;
 		}
+
+		_history.put(player.getUniqueId(), options);
+
 		int pageLength = JukeAlert.getInstance().getSettingsManager().getJaInfoLength(player.getUniqueId());
-		sendSnitchLog(player, snitch, offset, pageLength, filterAction, filterPlayer);
+
+		sendSnitchLog(player, snitch, options.pageNumber, pageLength, options.actionType, options.playerName, options.censor);
 	}
 
-	public void sendSnitchLog(Player player, Snitch snitch, int offset, int pageLength, String actionType,
-			String filterPlayerName) {
-		SnitchLogAppender logAppender = (SnitchLogAppender) snitch.getAppender(SnitchLogAppender.class);
+	public void sendSnitchLog(
+			Player player,
+			Snitch snitch,
+			int offset,
+			int pageLength,
+			String actionType,
+			String playerName,
+			boolean censor)
+	{
+		SnitchLogAppender logAppender = snitch.getAppender(SnitchLogAppender.class);
 		List<LoggableAction> logs = new ArrayList<>(logAppender.getFullLogs());
-		if (filterPlayerName != null) {
-			UUID filterUUID = NameAPI.getUUID(filterPlayerName);
-			if (filterUUID == null) {
-				player.sendMessage(ChatColor.RED + filterPlayerName + " is not a player");
-				return;
-			}
+		if (playerName != null) {
+			String playerNameLowered = playerName.toLowerCase();
 			List<LoggableAction> logCopy = new LinkedList<>();
 			for (LoggableAction log : logs) {
 				if (!((SnitchAction) log).hasPlayer()) {
 					continue;
 				}
 				PlayerAction playerAc = (PlayerAction) log;
-				if (playerAc.getPlayer().equals(filterUUID)) {
+				if (playerAc.getPlayerName().toLowerCase().contains(playerNameLowered)) {
 					logCopy.add(log);
 				}
 			}
 			logs = logCopy;
 		}
 		if (actionType != null) {
+			String actionTypeLowered = actionType.toLowerCase();
 			List<LoggableAction> logCopy = new LinkedList<>();
 			for (LoggableAction log : logs) {
-				if (((SnitchAction) log).getIdentifier().equals(actionType)) {
+				if (log.getChatRepresentationIdentifier().toLowerCase().contains(actionTypeLowered)) {
 					logCopy.add(log);
 				}
 			}
@@ -112,28 +226,7 @@ public class InfoCommand extends BaseCommand {
 		reply.addExtra(JAUtility.genTextComponent(snitch));
 		player.spigot().sendMessage(reply);
 		while (currentSlot++ < currentPageSize) {
-			player.spigot().sendMessage(iter.next().getChatRepresentation(player.getLocation(), false));
+			player.spigot().sendMessage(iter.next().getChatRepresentation(player.getLocation(), false, censor));
 		}
-	}
-
-	public List<String> tabComplete(CommandSender sender, String[] args) {
-		List<String> completedArgs = new ArrayList<>();
-		if (args.length > 0) {
-			// Copy all of the arguments except the last one to the output
-			for (int i = 0; i < args.length - 2; i++) {
-				completedArgs.add(args[i]);
-			}
-			// Try to complete the last argument
-			String lastArg = args[args.length - 1];
-			for (String command : autocompleteCommands) {
-				if (command.startsWith(lastArg)) {
-					lastArg = command;
-					break;
-				}
-			}
-			// Add the last argument to the output
-			completedArgs.add(lastArg);
-		}
-		return completedArgs;
 	}
 }

--- a/paper/src/main/java/com/untamedears/jukealert/model/actions/abstr/LoggableAction.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/actions/abstr/LoggableAction.java
@@ -16,10 +16,11 @@ public interface LoggableAction {
 	 * @param reference Current location of the player to show the output to
 	 * @param live      Whether the action is happening right now or being retrieved
 	 *                  as a record
+	 * @param censor    If True then override location by [*** *** ***]
 	 * @return TextComponent representing this instance ready for sending to a
 	 *         player
 	 */
-	TextComponent getChatRepresentation(Location reference, boolean live);
+	TextComponent getChatRepresentation(Location reference, boolean live, boolean censor);
 
 	LoggedActionPersistence getPersistence();
 
@@ -31,4 +32,5 @@ public interface LoggableAction {
 
 	ActionCacheState getCacheState();
 
+	String getChatRepresentationIdentifier();
 }

--- a/paper/src/main/java/com/untamedears/jukealert/model/actions/abstr/LoggablePlayerAction.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/actions/abstr/LoggablePlayerAction.java
@@ -62,21 +62,21 @@ public abstract class LoggablePlayerAction extends PlayerAction implements Logga
 	}
 	
 	@Override
-	public TextComponent getChatRepresentation(Location reference, boolean live) {
+	public TextComponent getChatRepresentation(Location reference, boolean live, boolean censor) {
 		Location referenceLoc = getLocationForStringRepresentation();
 		boolean sameWorld = JAUtility.isSameWorld(referenceLoc, reference);
+		String referenceLocText = censor ? "[*** *** ***]" : JAUtility.formatLocation(referenceLoc, !sameWorld);
+
 		TextComponent comp = new TextComponent(
 				String.format("%s%s  %s%s  ", ChatColor.GOLD, getChatRepresentationIdentifier(), ChatColor.GREEN, NameAPI.getCurrentName(getPlayer())));
 		if (live) {
 			comp.addExtra(JAUtility.genTextComponent(snitch));
-			comp.addExtra(String.format("  %s%s", ChatColor.YELLOW,
-					JAUtility.formatLocation(referenceLoc, !sameWorld)));
+			comp.addExtra(String.format("  %s%s", ChatColor.YELLOW, referenceLocText));
 		}
 		else {
 			//dont need to explicitly list location when retrieving logs and its the snitch location
 			if (referenceLoc != snitch.getLocation()) {
-				comp.addExtra(String.format("%s%s", ChatColor.YELLOW,
-						JAUtility.formatLocation(referenceLoc, !sameWorld)));
+				comp.addExtra(String.format("%s%s ", ChatColor.YELLOW, referenceLocText));
 			}
 			comp.addExtra(new TextComponent(ChatColor.AQUA + getFormattedTime()));
 		}
@@ -100,8 +100,6 @@ public abstract class LoggablePlayerAction extends PlayerAction implements Logga
 	protected Location getLocationForStringRepresentation() {
 		return snitch.getLocation();
 	}
-	
-	protected abstract String getChatRepresentationIdentifier();
 
 	protected IClickable getEnrichedClickableSkullFor(UUID uuid) {
 		CompletableFuture<ItemStack> itemReadyFuture = new CompletableFuture<>();

--- a/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/BlockBreakAction.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/BlockBreakAction.java
@@ -25,7 +25,7 @@ public class BlockBreakAction extends LoggableBlockAction {
 	}
 
 	@Override
-	protected String getChatRepresentationIdentifier() {
+	public String getChatRepresentationIdentifier() {
 		return "Break";
 	}
 

--- a/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/BlockPlaceAction.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/BlockPlaceAction.java
@@ -25,7 +25,7 @@ public class BlockPlaceAction extends LoggableBlockAction {
 	}
 
 	@Override
-	protected String getChatRepresentationIdentifier() {
+	public String getChatRepresentationIdentifier() {
 		return "Place";
 	}
 

--- a/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/DestroyVehicleAction.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/DestroyVehicleAction.java
@@ -39,7 +39,7 @@ public class DestroyVehicleAction extends LoggablePlayerVictimAction {
 	}
 
 	@Override
-	protected String getChatRepresentationIdentifier() {
+	public String getChatRepresentationIdentifier() {
 		return "Broke " + ItemUtils.getItemName(getVehicle());
 	}
 

--- a/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/DismountEntityAction.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/DismountEntityAction.java
@@ -30,7 +30,7 @@ public class DismountEntityAction extends LoggablePlayerVictimAction {
 	}
 
 	@Override
-	protected String getChatRepresentationIdentifier() {
+	public String getChatRepresentationIdentifier() {
 		return "Dismounted " + getVictim();
 	}
 

--- a/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/EmptyBucketAction.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/EmptyBucketAction.java
@@ -15,7 +15,7 @@ public class EmptyBucketAction extends LoggableBlockAction {
 	}
 
 	@Override
-	protected String getChatRepresentationIdentifier() {
+	public String getChatRepresentationIdentifier() {
 		return "Emptied bucket";
 	}
 

--- a/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/EnterFieldAction.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/EnterFieldAction.java
@@ -31,7 +31,7 @@ public class EnterFieldAction extends LoggablePlayerAction {
 	}
 
 	@Override
-	protected String getChatRepresentationIdentifier() {
+	public String getChatRepresentationIdentifier() {
 		return "Enter";
 	}
 }

--- a/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/EnterVehicleAction.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/EnterVehicleAction.java
@@ -39,7 +39,7 @@ public class EnterVehicleAction extends LoggablePlayerVictimAction {
 	}
 
 	@Override
-	protected String getChatRepresentationIdentifier() {
+	public String getChatRepresentationIdentifier() {
 		return "Entered " + ItemUtils.getItemName(getVehicle());
 	}
 

--- a/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/ExitVehicleAction.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/ExitVehicleAction.java
@@ -39,7 +39,7 @@ public class ExitVehicleAction extends LoggablePlayerVictimAction {
 	}
 	
 	@Override
-	protected String getChatRepresentationIdentifier() {
+	public String getChatRepresentationIdentifier() {
 		return "Exited " + ItemUtils.getItemName(getVehicle());
 	}
 

--- a/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/FillBucketAction.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/FillBucketAction.java
@@ -15,7 +15,7 @@ public class FillBucketAction extends LoggableBlockAction {
 	}
 
 	@Override
-	protected String getChatRepresentationIdentifier() {
+	public String getChatRepresentationIdentifier() {
 		return "Filled bucket";
 	}
 

--- a/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/IgniteBlockAction.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/IgniteBlockAction.java
@@ -51,7 +51,7 @@ public class IgniteBlockAction extends LoggablePlayerAction  {
 	}
 
 	@Override
-	protected String getChatRepresentationIdentifier() {
+	public String getChatRepresentationIdentifier() {
 		return "Ignited";
 	}
 

--- a/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/KillLivingEntityAction.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/KillLivingEntityAction.java
@@ -30,7 +30,7 @@ public class KillLivingEntityAction extends LoggablePlayerVictimAction {
 	}
 	
 	@Override
-	protected String getChatRepresentationIdentifier() {
+	public String getChatRepresentationIdentifier() {
 		return "Killed " + getVictim();
 	}
 

--- a/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/KillPlayerAction.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/KillPlayerAction.java
@@ -36,7 +36,7 @@ public class KillPlayerAction extends LoggablePlayerVictimAction {
 	}
 	
 	@Override
-	protected String getChatRepresentationIdentifier() {
+	public String getChatRepresentationIdentifier() {
 		return "Killed " + getVictimName();
 	}
 

--- a/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/LeaveFieldAction.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/LeaveFieldAction.java
@@ -24,7 +24,7 @@ public class LeaveFieldAction extends LoggablePlayerAction {
 	}
 
 	@Override
-	protected String getChatRepresentationIdentifier() {
+	public String getChatRepresentationIdentifier() {
 		return "Leave";
 	}
 

--- a/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/LoginAction.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/LoginAction.java
@@ -32,7 +32,7 @@ public class LoginAction extends LoggablePlayerAction {
 	}
 
 	@Override
-	protected String getChatRepresentationIdentifier() {
+	public String getChatRepresentationIdentifier() {
 		return ChatColor.BOLD + "Login";
 	}
 }

--- a/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/LogoutAction.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/LogoutAction.java
@@ -32,7 +32,7 @@ public class LogoutAction extends LoggablePlayerAction {
 	}
 
 	@Override
-	protected String getChatRepresentationIdentifier() {
+	public String getChatRepresentationIdentifier() {
 		return ChatColor.BOLD + "Logout";
 	}
 }

--- a/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/MountEntityAction.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/MountEntityAction.java
@@ -25,7 +25,7 @@ public class MountEntityAction extends LoggablePlayerVictimAction {
 	}
 	
 	@Override
-	protected String getChatRepresentationIdentifier() {
+	public String getChatRepresentationIdentifier() {
 		return "Mounted " + getVictim();
 	}
 

--- a/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/OpenContainerAction.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/actions/impl/OpenContainerAction.java
@@ -15,7 +15,7 @@ public class OpenContainerAction extends LoggableBlockAction {
 	}
 
 	@Override
-	protected String getChatRepresentationIdentifier() {
+	public String getChatRepresentationIdentifier() {
 		return "Opened";
 	}
 

--- a/paper/src/main/java/com/untamedears/jukealert/model/appender/BroadcastEntryAppender.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/appender/BroadcastEntryAppender.java
@@ -48,7 +48,7 @@ public class BroadcastEntryAppender extends ConfigurableSnitchAppender<LimitedAc
 				continue;
 			}
 			if (snitch.hasPermission(uuid, JukeAlertPermissionHandler.getSnitchAlerts())) {
-				TextComponent comp = log.getChatRepresentation(player.getLocation(), true);
+				TextComponent comp = log.getChatRepresentation(player.getLocation(), true, false);
 
 				if (settings.shouldShowDirections(uuid)) {
 					comp.addExtra(String.format("  %s", JAUtility.genDirections(snitch, player)));


### PR DESCRIPTION
/jainfo now supports three modes:
1. /jainfo - the same as it worked before
2. /jainfo [page_number] [censor] [action=action_type] [player=player_name] - show info by filter
3. /jainfo next - show the next page

Notes:
1. action_type - is the full or partial name of the action
2. player-name - is the full or partial name of the player who made this action
3. censor - the option which means that instead of coordinates will be shown [*** *** ***]