### PR TITLE
Add remote renaming via a new command; fix current /janame being unusable for snitches with spaces

### DIFF
--- a/paper/src/main/java/com/untamedears/jukealert/commands/JACommandManager.java
+++ b/paper/src/main/java/com/untamedears/jukealert/commands/JACommandManager.java
@@ -18,6 +18,7 @@ public class JACommandManager extends CommandManager {
 		registerCommand(new ListCommand());
 		registerCommand(new MuteCommand());
 		registerCommand(new NameCommand());
+		registerCommand(new NameAtCommand());
 		registerCommand(new ToggleLeverCommand());
 	}
 }

--- a/paper/src/main/java/com/untamedears/jukealert/commands/NameAtCommand.java
+++ b/paper/src/main/java/com/untamedears/jukealert/commands/NameAtCommand.java
@@ -30,7 +30,7 @@ public class NameAtCommand extends BaseCommand {
 		renameSnitch(player, parsed.snitchName, parsed.location);
 	}
 
-	private static ParsedArgs parseArgs(Player player, String[] args) throws InvalidCommandArgument  {
+	private static ParsedArgs parseArgs(Player player, String[] args) throws InvalidCommandArgument {
 		// Need at least 3 coordinates and a name.
 		if (args.length < 4) {
 			throw new InvalidCommandArgument("Not enough arguments.");
@@ -44,9 +44,9 @@ public class NameAtCommand extends BaseCommand {
 		if (!isInteger(args[0])) {
 			String worldName = args[0];
 			world = Bukkit.getWorld(worldName);
-	        if (world == null) {
+			if (world == null) {
 				throw new InvalidCommandArgument("Unknown world: " + worldName + ".");
-	        }
+			}
 			xIndex = 1;
 			yIndex = 2;
 			zIndex = 3;

--- a/paper/src/main/java/com/untamedears/jukealert/commands/NameAtCommand.java
+++ b/paper/src/main/java/com/untamedears/jukealert/commands/NameAtCommand.java
@@ -1,0 +1,114 @@
+package com.untamedears.jukealert.commands;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import co.aikar.commands.BaseCommand;
+import co.aikar.commands.annotation.CommandAlias;
+import co.aikar.commands.annotation.Description;
+import co.aikar.commands.InvalidCommandArgument;
+import co.aikar.commands.annotation.Syntax;
+import com.untamedears.jukealert.JukeAlert;
+import com.untamedears.jukealert.model.Snitch;
+import com.untamedears.jukealert.util.JAUtility;
+import com.untamedears.jukealert.util.JukeAlertPermissionHandler;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import vg.civcraft.mc.namelayer.permission.PermissionType;
+
+public class NameAtCommand extends BaseCommand {
+	private record ParsedArgs(Location location, String snitchName) {}
+
+	@CommandAlias("janameat")
+	@Syntax("[world] <x> <y> <z> <name>")
+	@Description("Name a snitch at the given location")
+	public void execute(Player player, String[] args) throws InvalidCommandArgument {
+		ParsedArgs parsed = parseArgs(player, args);
+		renameSnitch(player, parsed.snitchName, parsed.location);
+	}
+
+	private static ParsedArgs parseArgs(Player player, String[] args) throws InvalidCommandArgument  {
+		// Need at least 3 coordinates and a name.
+		if (args.length < 4) {
+			throw new InvalidCommandArgument("Not enough arguments.");
+		}
+
+		World world;
+		int xIndex;
+		int yIndex;
+		int zIndex;
+		// If the first arg is not a number, then it must be the world.
+		if (!isInteger(args[0])) {
+			String worldName = args[0];
+			world = Bukkit.getWorld(worldName);
+	        if (world == null) {
+				throw new InvalidCommandArgument("Unknown world: " + worldName + ".");
+	        }
+			xIndex = 1;
+			yIndex = 2;
+			zIndex = 3;
+
+			// The world was provided, so we need at least 5 args now.
+			if (args.length < 5) {
+				throw new InvalidCommandArgument("Not enough arguments.");
+			}
+		} else {
+			world = player.getLocation().getWorld();
+			xIndex = 0;
+			yIndex = 1;
+			zIndex = 2;
+		}
+
+		int x;
+		int y;
+		int z;
+		try {
+			x = Integer.parseInt(args[xIndex]);
+			y = Integer.parseInt(args[yIndex]);
+			z = Integer.parseInt(args[zIndex]);
+		} catch (NumberFormatException e) {
+			throw new InvalidCommandArgument(
+				String.format("Coordinates must be numbers: %s %s %s.", args[xIndex], args[yIndex], args[zIndex]));
+		}
+
+		String snitchName = Stream.of(args).skip(zIndex+1).collect(Collectors.joining(" "));
+
+		return new ParsedArgs(new Location(world, x, y, z), snitchName);
+	}
+
+	private static boolean isInteger(String arg) {
+		try {
+			Integer.parseInt(arg);
+		} catch (NumberFormatException e) {
+			return false;
+		}
+		return true;
+	}
+
+	private static void renameSnitch(Player player, String name, Location location) {
+		Snitch snitch = JukeAlert.getInstance().getSnitchManager().getSnitchAt(location);
+		if (snitch == null || !snitch.hasPermission(player, getPermission())) {
+			player.sendMessage(
+					ChatColor.RED + "You do not own a snitch at those coordinates or lack permission to rename it!");
+			return;
+		}
+
+		String newName = name.length() > 40
+			? name.substring(0, 40)
+			: name;
+
+		String prevName = snitch.getName();
+		JukeAlert.getInstance().getSnitchManager().renameSnitch(snitch, newName);
+		TextComponent lineText = new TextComponent(ChatColor.AQUA + " Changed snitch name to ");
+		lineText.addExtra(JAUtility.genTextComponent(snitch));
+		lineText.addExtra(ChatColor.AQUA + " from " + ChatColor.GOLD + prevName);
+		player.spigot().sendMessage(lineText);
+	}
+
+	private static PermissionType getPermission() {
+		return JukeAlertPermissionHandler.getRenameSnitch();
+	}
+}

--- a/paper/src/main/java/com/untamedears/jukealert/commands/NameCommand.java
+++ b/paper/src/main/java/com/untamedears/jukealert/commands/NameCommand.java
@@ -2,7 +2,6 @@ package com.untamedears.jukealert.commands;
 
 import static com.untamedears.jukealert.util.JAUtility.findLookingAtOrClosestSnitch;
 
-
 import co.aikar.commands.BaseCommand;
 import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.Description;
@@ -12,10 +11,7 @@ import com.untamedears.jukealert.model.Snitch;
 import com.untamedears.jukealert.util.JAUtility;
 import com.untamedears.jukealert.util.JukeAlertPermissionHandler;
 import net.md_5.bungee.api.chat.TextComponent;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
-import org.bukkit.Location;
-import org.bukkit.World;
 import org.bukkit.entity.Player;
 import vg.civcraft.mc.namelayer.permission.PermissionType;
 
@@ -32,40 +28,6 @@ public class NameCommand extends BaseCommand {
 		}
 
 		renameSnitch(player, snitchName, snitch);
-	}
-
-	@CommandAlias("janame")
-	@Syntax("<world> <x> <y> <z> <name>")
-	@Description("Name a snitch")
-	public void execute(Player player, String worldName, int x, int y, int z, String snitchName) {
-		World world = Bukkit.getWorld(worldName);
-		if (world == null) {
-			player.sendMessage(ChatColor.RED + "Invalid world.");
-			return;
-		}
-
-		Location location = new Location(world, x, y, z);
-		renameSnitch(player, snitchName, location);
-	}
-
-	@CommandAlias("janame")
-	@Syntax("<x> <y> <z> <name>")
-	@Description("Name a snitch")
-	public void execute(Player player, int x, int y, int z, String snitchName) {
-		World world = player.getLocation().getWorld();
-		Location location = new Location(world, x, y, z);
-		renameSnitch(player, snitchName, location);
-	}
-
-	private static void renameSnitch(Player player, String name, Location location) {
-		Snitch snitch = JukeAlert.getInstance().getSnitchManager().getSnitchAt(location);
-		if (snitch == null || !snitch.hasPermission(player, getPermission())) {
-			player.sendMessage(
-					ChatColor.RED + "You do not own a snitch at those coordinates or lack permission to rename it!");
-			return;
-		}
-
-		renameSnitch(player, name, snitch);
 	}
 
 	private static void renameSnitch(Player player, String name, Snitch snitch) {


### PR DESCRIPTION
Supersedes https://github.com/CivMC/JukeAlert/pull/32.

Adds a new command `/janameat` instead of overloading `/janame` to allow for a more user-friendly experience - no need to use quotes to name snitches with spaces.

Tested:
 - `/janame` works the same as before.
   - Snitch names with spaces work.
 - `/janameat`:
   - Works when the world is provided.
   - Works when the world is omitted.
   - Works with snitch names with spaces.
   - Fails with reasonably helpful error messages on:
     - Too few arguments.
     - Unknown world.
     - Coordinates that are not numbers.
     - Snitch name not provided.

Thanks to @Aleksey-Terzi for support and the code in https://github.com/CivMC/JukeAlert/pull/32.