### PR TITLE
Fix dormant snitches still being active & snitches not changing state over restarts

### DIFF
--- a/paper/src/main/java/com/untamedears/jukealert/model/Snitch.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/Snitch.java
@@ -214,6 +214,14 @@ public class Snitch extends LocationTrackable {
 	}
 
 	/**
+	 * Returns a boolean representing whether the snitch is currently active (e.g., recording snitch hits)
+	 * Currently used to synchronise the state in DormantCullingAppender with the real activity of the snitch.
+	 */
+	public boolean getActiveStatus() {
+		return this.active;
+	}
+
+	/**
 	 * Forces all appenders of this snitch to persist their current state
 	 */
 	public void persistAppenders() {

--- a/paper/src/main/java/com/untamedears/jukealert/model/appender/DormantCullingAppender.java
+++ b/paper/src/main/java/com/untamedears/jukealert/model/appender/DormantCullingAppender.java
@@ -97,15 +97,11 @@ public class DormantCullingAppender
 		this.nextUpdate = update;
 	}
 
-	private long calcFutureUpdate() {
-		switch (getActivityStatus()) {
-			case CULLED:
-				return Long.MAX_VALUE;
-			case DORMANT:
-				return getLastRefresh() + this.config.getTotalLifeTime();
-			default:
-			case ACTIVE:
-				return getLastRefresh() + this.config.getLifetime();
+	private void syncNextUpdate() {
+		switch (this.databaseKnownStatus) {
+			case CULLED -> cullSnitch();
+			case DORMANT -> deactivateSnitch();
+			default -> updateInternalProgressTime(getLastRefresh() + this.config.getLifetime());
 		}
 	}
 
@@ -117,9 +113,8 @@ public class DormantCullingAppender
 			updateLastRefresh();
 		}
 		this.databaseKnownStatus = getActivityStatus();
-		updateInternalProgressTime(calcFutureUpdate());
+		syncNextUpdate();
 		JukeAlert.getInstance().getSnitchCullManager().addCulling(this);
-		updateState();
 	}
 
 	/** {@inheritDoc} */
@@ -182,24 +177,35 @@ public class DormantCullingAppender
 		final ActivityStatus currentStatus = getActivityStatus();
 		// Culled
 		if (currentStatus == ActivityStatus.CULLED && this.databaseKnownStatus != ActivityStatus.CULLED) {
-			this.databaseKnownStatus = ActivityStatus.CULLED;
-			getSnitch().destroy(null, Cause.CULL);
-			updateInternalProgressTime(Long.MAX_VALUE);
-			LOGGER.info("Culling snitch [" + getSnitch() + "] for exceeding life timer");
+			cullSnitch();
 		}
 		// Dormant
 		else if (currentStatus == ActivityStatus.DORMANT && this.databaseKnownStatus != ActivityStatus.DORMANT) {
-			this.databaseKnownStatus = ActivityStatus.DORMANT;
-			updateInternalProgressTime(System.currentTimeMillis() + this.config.getDormantLifeTime());
-			getSnitch().setActiveStatus(false);
-			LOGGER.info("Deactivating snitch [" + getSnitch() + "] for exceeding dormant timer");
+			deactivateSnitch();
 		}
 		// Active
-		else if (this.databaseKnownStatus != ActivityStatus.ACTIVE) {
+		else if (currentStatus == ActivityStatus.ACTIVE && this.databaseKnownStatus != ActivityStatus.ACTIVE) {
 			this.databaseKnownStatus = ActivityStatus.ACTIVE;
 			getSnitch().setActiveStatus(true);
-			JukeAlert.getInstance().getSnitchCullManager().updateCulling(this, calcFutureUpdate());
+			syncNextUpdate();
+			JukeAlert.getInstance().getSnitchCullManager().updateCulling(this, this.getNextUpdate());
 			LOGGER.info("Re-activating snitch [" + getSnitch() + "]");
+		}
+	}
+
+	private void cullSnitch() {
+		this.databaseKnownStatus = ActivityStatus.CULLED;
+		getSnitch().destroy(null, Cause.CULL);
+		updateInternalProgressTime(Long.MAX_VALUE);
+		LOGGER.info("Culling snitch [" + getSnitch() + "] for exceeding life timer");
+	}
+
+	private void deactivateSnitch() {
+		updateInternalProgressTime(getLastRefresh() + this.config.getTotalLifeTime());
+		this.databaseKnownStatus = ActivityStatus.DORMANT;
+		if (getSnitch().getActiveStatus()) {
+			getSnitch().setActiveStatus(false);
+			LOGGER.info("Deactivating snitch [" + getSnitch() + "] for exceeding dormant timer");
 		}
 	}
 


### PR DESCRIPTION
1. If a snitch changed from active to dormant or dormant to culled during a restart, it would not actually change state. This could result in a snitch remaining active indefinitely, but this would be rather rare.
2. Separately (and the original issue that prompted this fix), was that dormant snitches would still send notifications. This is because, on server startup, dormant snitches would be re-activated (if they were disabled previously) due to incorrect logic.

Fixes #37 