### PR TITLE
Potentially improve performance of /jalist

### DIFF
--- a/paper/src/main/java/com/untamedears/jukealert/gui/SnitchOverviewGUI.java
+++ b/paper/src/main/java/com/untamedears/jukealert/gui/SnitchOverviewGUI.java
@@ -2,7 +2,7 @@ package com.untamedears.jukealert.gui;
 
 import com.untamedears.jukealert.model.Snitch;
 import com.untamedears.jukealert.model.appender.DormantCullingAppender;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.entity.Player;

--- a/paper/src/main/java/com/untamedears/jukealert/gui/SnitchOverviewGUI.java
+++ b/paper/src/main/java/com/untamedears/jukealert/gui/SnitchOverviewGUI.java
@@ -30,7 +30,7 @@ public class SnitchOverviewGUI {
 	}
 
 	private List<IClickable> constructSnitchClickables() {
-		final List<IClickable> clickables = new ArrayList<>();
+		final List<IClickable> clickables = new ArrayList<>(this.snitches.size());
 		for (final Snitch snitch : this.snitches) {
 			// Base the snitch icon on the snitch type
 			final var icon = snitch.getType().getItem().clone();

--- a/paper/src/main/java/com/untamedears/jukealert/gui/SnitchOverviewGUI.java
+++ b/paper/src/main/java/com/untamedears/jukealert/gui/SnitchOverviewGUI.java
@@ -30,7 +30,7 @@ public class SnitchOverviewGUI {
 	}
 
 	private List<IClickable> constructSnitchClickables() {
-		final List<IClickable> clickables = new LinkedList<>();
+		final List<IClickable> clickables = new ArrayList<>();
 		for (final Snitch snitch : this.snitches) {
 			// Base the snitch icon on the snitch type
 			final var icon = snitch.getType().getItem().clone();


### PR DESCRIPTION
The LinkedList of `clickables` will contain as many entries as there are snitches to display, so potentially thousands.

Then [this loop](https://github.com/CivMC/CivModCore/blob/master/paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/gui/MultiPageView.java#L47) will call `.get()` on the list ~45 times per page. Because it's a linked list, each `.get()` will be O(n). Moreover, because it's not just iterating through the list, but rather incrementing an integer and calling `.get(i)`, the performance is as bad as can be. 

The list never seems to get modified after creation, so there's literally no benefit to using a linked list over an array here, only massive downsides.

Not tested 🤷🏽‍♀️ 